### PR TITLE
Added textContentType attribute 

### DIFF
--- a/CBPinEntryView/Classes/CBPinEntryView.swift
+++ b/CBPinEntryView/Classes/CBPinEntryView.swift
@@ -81,6 +81,17 @@ public protocol CBPinEntryViewDelegate: class {
     @IBInspectable open var secureCharacter: String = CBPinEntryViewDefaults.secureCharacter
 
     @IBInspectable open var keyboardType: Int = CBPinEntryViewDefaults.keyboardType
+    
+    open var textContentType: UITextContentType? {
+        didSet {
+            if #available(iOS 10, *) {
+                if let contentType = textContentType {
+                    textField.textContentType = contentType
+                }
+            }
+        }
+    }
+
 
     private var stackView: UIStackView?
     private var textField: UITextField!

--- a/Example/CBPinEntryView/ViewController.swift
+++ b/Example/CBPinEntryView/ViewController.swift
@@ -18,6 +18,13 @@ class ViewController: UIViewController {
     }
     @IBOutlet var stringOutputLabel: UILabel!
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if #available(iOS 12, *) {
+            pinEntryView.textContentType = .oneTimeCode
+        }
+    }
+    
     @IBAction func pressedGetCode(_ sender: UIButton) {
         stringOutputLabel.text = pinEntryView.getPinAsString()
         print(pinEntryView.getPinAsInt() ?? "Nothing entered")


### PR DESCRIPTION
Added `textContentType` attribute in order to support semantic intention and features like autofill OTP  code.

#### Usage:
```
        if #available(iOS 12, *) {
            pinEntryView.textContentType = .oneTimeCode
        }
```

This pr solves issue #11 
Pay attention, that autofill will not work with third-party keyboards for security reasons.

More info at Apple Docs - https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_a_text_input_view